### PR TITLE
Renaming slimscroll with slimScroll

### DIFF
--- a/DependencyInjection/AvanzuAdminThemeExtension.php
+++ b/DependencyInjection/AvanzuAdminThemeExtension.php
@@ -86,7 +86,7 @@ class AvanzuAdminThemeExtension extends Extension implements PrependExtensionInt
                                           $lteJs . 'plugins/bootstrap-slider/bootstrap-slider.js',
                                           $lteJs . 'plugins/datatables/jquery.dataTables.js',
                                           $lteJs . 'plugins/datatables/dataTables.bootstrap.js',
-                                          $lteJs . 'plugins/slimscroll/jquery.slimscroll.js',
+                                          $lteJs . 'plugins/slimScroll/jquery.slimscroll.js',
                                           $jsAssets . 'public/js/adminLTE.js',
                                       )
                                   ),


### PR DESCRIPTION
I have an error after executing app/console avanzu:admin:fetch-vendor

Cannot import resource "." from "--/app/cache/dev/assetic/routing.yml". (Unable to find file "@AvanzuAdminThemeBundle/Resources/public/vendor/AdminLTE/js/plugins/slimscroll/jquery.slimscroll.js

The path exists "vendor/AdminLTE/js/plugins/slimScroll" but not "vendor/AdminLTE/js/plugins/slimscroll" doesn't exists.
