### PR TITLE
Use "bundles/avanzuadmintheme" instead of @AvanzuAdminThemeBundle

### DIFF
--- a/DependencyInjection/AvanzuAdminThemeExtension.php
+++ b/DependencyInjection/AvanzuAdminThemeExtension.php
@@ -39,8 +39,8 @@ class AvanzuAdminThemeExtension extends Extension implements PrependExtensionInt
     {
         $bundles = $container->getParameter('kernel.bundles');
 
-        $jsAssets  = '@AvanzuAdminThemeBundle/Resources/';
-        $lteJs     = $jsAssets . 'public/vendor/AdminLTE/js/';
+        $jsAssets  = 'bundles/avanzuadmintheme/';
+        $lteJs     = $jsAssets . 'vendor/AdminLTE/js/';
         $cssAssets = 'bundles/avanzuadmintheme/';
         $lteCss    = $cssAssets . 'vendor/AdminLTE/css/';
         $lteFont   = $cssAssets . 'vendor/AdminLTE/fonts/';

--- a/Resources/config/assets.yml
+++ b/Resources/config/assets.yml
@@ -1,4 +1,4 @@
 common_js:
     inputs:
-        - '@AvanzuAdminThemeBundle/Resources/public/vendor/jquery/dist/jquery.js'
-        - '@AvanzuAdminThemeBundle/Resources/public/vendor/jquery-ui/ui/jquery-ui.js'
+        - %kernel.root_dir%/../web/bundles/avanzuadmintheme/vendor/jquery/dist/jquery.js
+        - %kernel.root_dir%/../web/bundles/avanzuadmintheme/vendor/jquery-ui/ui/jquery-ui.js

--- a/Resources/views/layout/base-layout.html.twig
+++ b/Resources/views/layout/base-layout.html.twig
@@ -22,7 +22,7 @@
 
     {# --------------------------------------------------------------------------------------------- JAVASCRIPTS_HEAD #}
     {%  block javascripts_head %}
-    {% javascripts '@AvanzuAdminThemeBundle/Resources/public/vendor/modernizr/modernizr.js'%}
+    {% javascripts 'bundles/avanzuadmintheme/vendor/modernizr/modernizr.js'%}
         <script type="text/javascript" src="{{ asset(asset_url) }}"></script>
     {% endjavascripts %}
         <!--[if lt IE 9]>


### PR DESCRIPTION
This change allows the possibility to send the "web/bundles/avanzuadmintheme" in the repository
in order to avoid the execution of bower.
