### PR TITLE
increase bower timeout

### DIFF
--- a/Command/FetchVendorCommand.php
+++ b/Command/FetchVendorCommand.php
@@ -42,6 +42,7 @@ class FetchVendorCommand extends ContainerAwareCommand {
 
         $action = $input->getOption('update') ? 'update' : 'install';
         $process = new Process($bower.' '.$action);
+        $process->setTimeout(600);
         $output->writeln($helper->formatSection('Executing',$process->getCommandLine(), 'comment'));
         $process->setWorkingDirectory($res);
         $process->run(function($type, $buffer) use ($output, $helper){


### PR DESCRIPTION
default timeout 60 seconds is too low

```
$ app/console avanzu:admin:fetch-vendor
[Executing] /home/glen/scm/delfi/mds/app/../bin/bowerphp install
[Progress] bower jquery#*             
[Progress] bower jquery#2.1.1             install
[Progress] bower jquery-ui#*          
[Progress] bower jquery-ui#1.11.0         install
[Progress] bower momentjs#*           
[Progress] bower momentjs#2.8.0           install
[Progress] bower backbone#*           
[Progress] bower backbone#1.1.2           install
[Progress] bower underscore#>=1.5.0   



  [Symfony\Component\Process\Exception\ProcessTimedOutException]                                          
  The process "/home/glen/myapp/app/../bin/bowerphp install" exceeded the timeout of 60 seconds.  



avanzu:admin:fetch-vendor [-u|--update]
```
