### PR TITLE
composer command

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * This file is part of AvanzuAdminThemeBundle.
+ *
+ * (c) 2014 Elan Ruusamäe <glen@delfi.ee>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Avanzu\AdminThemeBundle\Composer;
+
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Composer\Script\CommandEvent;
+
+/**
+ * ScriptHandler
+ *
+ * @package    AvanzuAdminThemeBundle
+ * @subpackage Composer
+ * @author     Elan Ruusamäe <glen@delfi.ee>
+ * @copyright  2014 Elan Ruusamäe
+ * @license    http://opensource.org/licenses/MIT The MIT License
+ *
+ * @codeCoverageIgnore
+ */
+class ScriptHandler {
+    /**
+     * @param CommandEvent $event
+     */
+    public static function install(CommandEvent $event) {
+        $options = self::getOptions($event);
+        $consolePathOptionsKey = array_key_exists('symfony-bin-dir', $options) ? 'symfony-bin-dir' : 'symfony-app-dir';
+        $consolePath = $options[$consolePathOptionsKey];
+
+        if (!is_dir($consolePath)) {
+            printf(
+                'The %s (%s) specified in composer.json was not found in %s, can not fetch vendors.%s',
+                $consolePathOptionsKey,
+                $consolePath,
+                getcwd(),
+                PHP_EOL
+            );
+
+            return;
+        }
+
+        static::executeCommand($event, $consolePath, 'avanzu:admin:fetch-vendor', $options['process-timeout']);
+    }
+
+    protected static function executeCommand(CommandEvent $event, $consolePath, $cmd, $timeout = 300) {
+        $php = escapeshellarg(self::getPhp());
+        $console = escapeshellarg($consolePath . '/console');
+        if ($event->getIO()->isDecorated()) {
+            $console .= ' --ansi';
+        }
+
+        $process = new Process($php . ' ' . $console . ' ' . $cmd, null, null, null, $timeout);
+        $process->run(function ($type, $buffer) {
+            echo $buffer;
+        });
+        if (!$process->isSuccessful()) {
+            throw new \RuntimeException(
+                sprintf('An error occurred when executing the "%s" command.', escapeshellarg($cmd))
+            );
+        }
+    }
+
+    protected static function getOptions(CommandEvent $event) {
+        $options = array_merge(array(
+            'symfony-app-dir' => 'app',
+            'symfony-web-dir' => 'web',
+            'symfony-assets-install' => 'hard'
+        ), $event->getComposer()->getPackage()->getExtra());
+
+        $options['symfony-assets-install'] = getenv('SYMFONY_ASSETS_INSTALL') ?: $options['symfony-assets-install'];
+
+        $options['process-timeout'] = $event->getComposer()->getConfig()->get('process-timeout');
+
+        return $options;
+    }
+
+    protected static function getPhp() {
+        $phpFinder = new PhpExecutableFinder;
+        if (!$phpPath = $phpFinder->find()) {
+            throw new \RuntimeException(
+                'The php executable could not be found, add it to your PATH environment variable and try again'
+            );
+        }
+
+        return $phpPath;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -6,18 +6,6 @@ This bundle integrates several commonly used javascripts and the awesome [AdminL
 
 ## Installation
 
-Add AdminThemeBundle to composer.json
-```json
-	{
-		"require": {
-			"avanzu/admin-theme-bundle": "1.1.4"
-		}
-	}
-```
-tell composer to download the bundle
-
-	php composer.phar update avanzu/admin-theme-bundle
-
 Enable the bundle in your kernel:
 ```php
 	<?php
@@ -32,6 +20,23 @@ Enable the bundle in your kernel:
 	}
 ```
 
+Add AdminThemeBundle to composer.json
+```json
+	{
+		"require": {
+			"avanzu/admin-theme-bundle": "1.1.4"
+		},
+	    "scripts": {
+	        "post-install-cmd": [
+	            "Avanzu\\AdminThemeBundle\\Composer\\ScriptHandler::install"
+	        ],
+	        "post-update-cmd": [
+	            "Avanzu\\AdminThemeBundle\\Composer\\ScriptHandler::install"
+	        ]
+	    },
+	}
+```
+
 Configure bower path if neccessary (default value is `/usr/local/bin/bower`)
 
 ```yaml
@@ -42,13 +47,17 @@ Configure bower path if neccessary (default value is `/usr/local/bin/bower`)
     	bower_bin: /usr/local/bin/bower # that's the default value
 ```
 
-Fetch vendor scripts
+Finally tell composer to download the bundle
 
-	app/console avanzu:admin:fetch-vendor
+	php composer.phar update avanzu/admin-theme-bundle
 
 install assets (preferably using symlink method but hardcopy works as well)
 
 	app/console assets:install --symlink
+
+If you need to invoke bower to refetch vendor scripts (ran automatically by composer):
+
+	app/console avanzu:admin:fetch-vendor -u
 
 ### Next Steps
 * [Using the layout](Resources/docs/layout.md)

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "avanzu/admin-theme-bundle",
-    "description": "Admin Theme based on the AdminLTE Template for easy integration into symfony",
+    "description": "Admin Theme based on the AdminLTE Template for easy integration into Symfony",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
implement #23 

NOTE that I had to update README as the sequence of configuring things have changed.

Ideally the old command could be just dropped and all code moved to Composer Command as the composer commands can be re-ran:

```
$ composer run-script post-install-cmd
Updating the "app/config/parameters.yml" file
Clearing the cache for the dev environment with debug true
Installing assets using the hard copy option
Installing assets for Symfony\Bundle\FrameworkBundle into web/bundles/framework
Installing assets for Avanzu\AdminThemeBundle into web/bundles/avanzuadmintheme
Installing assets for Acme\DemoBundle into web/bundles/acmedemo
Installing assets for Sensio\Bundle\DistributionBundle into web/bundles/sensiodistribution
[Executing] /usr/bin/bower install 
$ 
```
