### PR TITLE
Make usage of assetic optional

### DIFF
--- a/DependencyInjection/AvanzuAdminThemeExtension.php
+++ b/DependencyInjection/AvanzuAdminThemeExtension.php
@@ -55,7 +55,10 @@ class AvanzuAdminThemeExtension extends Extension implements PrependExtensionInt
             );
         }
 
-        if (isset($bundles['AsseticBundle'])) {
+        $configs = $container->getExtensionConfig($this->getAlias());
+        $config = $this->processConfiguration(new Configuration(), $configs);
+
+        if ($config['use_assetic'] && isset($bundles['AsseticBundle'])) {
 
             $assets = include(dirname(__FILE__).'/../Resources/config/assets.php');
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -24,6 +24,9 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('bower_bin')
                         ->defaultValue('/usr/local/bin/bower')
                     ->end()
+                    ->scalarNode('use_assetic')
+                        ->defaultValue(true)
+                    ->end()
                 ->end();
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for

--- a/README.md
+++ b/README.md
@@ -39,7 +39,14 @@ install assets (preferably using symlink method but hardcopy works as well)
 	app/console assets:install --symlink
 
 ### Upgrade notice
-Version >= 1.3 comes with pre packaged asset files located under `Resources/public/static/[prod|dev]`. So, there is no longer a strict requirement for bower and/or assetic. The assetic groups hovever, are still there and should work as usual.
+Version >= 1.3 comes with pre packaged asset files located under `Resources/public/static/[prod|dev]`. So, there is no longer a strict requirement for bower and/or assetic. The assetic groups however, are still there and should work as usual.
+
+If the assetic bundle is installed but you don't want the AdminThemeBundle to use it you can add following lines to `config.yml`:
+
+```
+    avanzu_admin_theme:
+        use_assetic: false
+```
 
 
 ### Next Steps


### PR DESCRIPTION
As stated in the AdminThemeBundle documentation the use of assetic for the bundle is optional as it also works with the use of `assets:install`. But until now assetic was always used in case the AsseticBundle was installed. That means that you were also forced to install node and bower just because some other bundle made use of assetic.

With the PR the usage of assetic is really optional.

It is also backwards compatible. So if the configuration is not changed the behavior is exactly the same as before.

This PR is also a workaround for issue #36 