### PR TITLE
pin moderniz.js on version >=2.0.0 < 3.0 fixes #55

### DIFF
--- a/Resources/bower/bower.json
+++ b/Resources/bower/bower.json
@@ -21,7 +21,7 @@
         "momentjs"                  : "*",
         "backbone"                  : "*",
         "underscore"                : ">=1.0.0 <2.0",
-        "modernizr"                 : "*",
+        "modernizr"                 : ">=2.5.0 <3.0",
         "spinjs"                    : "*",
         "marionette"                : "*",
         "pickadate"                 : "*",


### PR DESCRIPTION
This should fix the issue by pinning on version two of modernizr, v3 doesn't include modernizr.js as it has to be built.