### PR TITLE
Sidebar navigation labels support

### DIFF
--- a/Resources/docs/sidebar_navigation.md
+++ b/Resources/docs/sidebar_navigation.md
@@ -17,8 +17,17 @@ class MenuItemModel implements ThemeMenuItem {
 	// ...
 }
 ```
-The bundle provides the `MenuItemModel` as a ready to use implementation of the `MenuItemInterface`.
+The bundle provides the `MenuItemModel` as a ready to use implementation of the `MenuItemInterface`. You can use it to create a menu item
 
+```php
+$manuItem = new \Avanzu\AdminThemeBundle\Model\MenuItemModel('item', 'Item', 'item_route_name');
+```
+
+or a menu label
+
+```php
+$menuLabel = new \Avanzu\AdminThemeBundle\Model\MenuItemModel('label', 'Label', false);
+```
 
 ### Event Listener
 Next, you will need to create an EventListener to work with the `MenuItemListEvent`.

--- a/Resources/views/layout/macros.html.twig
+++ b/Resources/views/layout/macros.html.twig
@@ -38,27 +38,36 @@
 {% endmacro %}
 
 {% macro menu_item(item) %}
-    <li id="{{ item.identifier }}" class=" {{ item.isActive ? 'active' : '' }} {{ item.hasChildren? 'treeview' : '' }}">
-        <a href="{{ item.hasChildren ? '#': '/' in item.route ? item.route : path(item.route, item.routeArgs) }}">
-            {% if item.icon %} <i class="{{ item.icon }}"></i> {% endif %}
-            <span>{{ item.label }}</span>
+    {% if item.route %}
+        <li id="{{ item.identifier }}" class=" {{ item.isActive ? 'active' : '' }} {{ item.hasChildren? 'treeview' : '' }}">
+            <a href="{{ item.hasChildren ? '#': '/' in item.route ? item.route : path(item.route, item.routeArgs) }}">
+                {% if item.icon %} <i class="{{ item.icon }}"></i> {% endif %}
+                <span>{{ item.label }}</span>
+                {% if item.badge %}
+                    <small class="label pull-right bg-{{ item.badgeColor }}">{{ item.badge }}</small>
+                {% endif %}
+                {% if item.hasChildren %}<i class="fa fa-angle-left pull-right"></i>{% endif %}
+            </a>
+
+            {% if item.hasChildren %}
+                <ul class="treeview-menu">
+                    {% for child in item.children %}
+                        <li class="{{ child.isActive ? 'active':'' }}" id="{{ child.identifier }}">
+                            <a href="{{ '/' in child.route ? child.route : path(child.route, child.routeArgs) }}">
+                                <i class="fa fa-circle-o"></i>
+                                {{ child.label }}
+                            </a>
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
+        </li>
+    {% else %}
+        <li class="header">
+            {{ item.label }}
             {% if item.badge %}
                 <small class="label pull-right bg-{{ item.badgeColor }}">{{ item.badge }}</small>
             {% endif %}
-            {% if item.hasChildren %}<i class="fa fa-angle-left pull-right"></i>{% endif %}
-        </a>
-
-        {% if item.hasChildren %}
-            <ul class="treeview-menu">
-                {% for child in item.children %}
-                    <li class="{{ child.isActive ? 'active':'' }}" id="{{ child.identifier }}">
-                        <a href="{{ '/' in child.route ? child.route : path(child.route, child.routeArgs) }}">
-                            <i class="fa fa-circle-o"></i>
-                            {{ child.label }}
-                        </a>
-                    </li>
-                {% endfor %}
-            </ul>
-        {% endif %}
-    </li>
+        </li>
+    {% endif %}
 {% endmacro %}


### PR DESCRIPTION
No backward incompatibilities. Example usage:

```php
<?php
namespace MyAdminBundle\EventListener;

// ...

use Avanzu\AdminThemeBundle\Model\MenuItemModel;
use Symfony\Component\HttpFoundation\Request;

class MyMenuItemListListener {

    // ...

    protected function getMenu(Request $request) {
        return array(
			new MenuItemModel('label', 'Label', false),
		);
    }

    // ...

}
```