### PR TITLE
Child menu item icons

### DIFF
--- a/Resources/docs/sidebar_navigation.md
+++ b/Resources/docs/sidebar_navigation.md
@@ -57,8 +57,17 @@ class MyMenuItemListListener {
 
 	protected function getMenu(Request $request) {
 		// Build your menu here by constructing a MenuItemModel array
-		$menuItems = array();
+		$menuItems = array(
+            $blog = new MenuItemModel('ItemId', 'ItemDisplayName', 'item_symfony_route', array(/* options */), 'iconclasses fa fa-plane');
+        );
 
+        // Add some children
+
+        // A child with an icon
+        $blog->addChild(new MenuItemModel('ChildOneItemId', 'ChildOneDisplayName', 'child_1_route', array(), 'fa fa-rss-square'));
+
+        // A child with default circle icon
+        $blog->addChild(new MenuItemModel('ChildTwoItemId', 'ChildTwoDisplayName', 'child_2_route'));
 		return $this->activateByRoute($request->get('_route'), $menuItems);
 	}
 

--- a/Resources/docs/sidebar_navigation.md
+++ b/Resources/docs/sidebar_navigation.md
@@ -20,7 +20,7 @@ class MenuItemModel implements ThemeMenuItem {
 The bundle provides the `MenuItemModel` as a ready to use implementation of the `MenuItemInterface`. You can use it to create a menu item
 
 ```php
-$manuItem = new \Avanzu\AdminThemeBundle\Model\MenuItemModel('item', 'Item', 'item_route_name');
+$menuItem = new \Avanzu\AdminThemeBundle\Model\MenuItemModel('item', 'Item', 'item_route_name');
 ```
 
 or a menu label

--- a/Resources/views/layout/macros.html.twig
+++ b/Resources/views/layout/macros.html.twig
@@ -54,7 +54,7 @@
                     {% for child in item.children %}
                         <li class="{{ child.isActive ? 'active':'' }}" id="{{ child.identifier }}">
                             <a href="{{ '/' in child.route ? child.route : path(child.route, child.routeArgs) }}">
-                                <i class="fa fa-circle-o"></i>
+                                <i class="{{ child.icon|default('fa fa-circle-o') }}"></i>
                                 {{ child.label }}
                             </a>
                         </li>

--- a/Resources/views/layout/macros.html.twig
+++ b/Resources/views/layout/macros.html.twig
@@ -38,7 +38,7 @@
 {% endmacro %}
 
 {% macro menu_item(item) %}
-    {% if item.route %}
+    {% if item.route or item.hasChildren %}
         <li id="{{ item.identifier }}" class=" {{ item.isActive ? 'active' : '' }} {{ item.hasChildren? 'treeview' : '' }}">
             <a href="{{ item.hasChildren ? '#': '/' in item.route ? item.route : path(item.route, item.routeArgs) }}">
                 {% if item.icon %} <i class="{{ item.icon }}"></i> {% endif %}


### PR DESCRIPTION
Documentation didn't mention children menu items couldn't have icons before, so I added the functionality.

Also had to bypass a recently added restriction on sidebar navigation items requiring a route on menu item parents to show children. 

Discussion about it starts here: https://github.com/avanzu/AdminThemeBundle/issues/69#issuecomment-158660522