### PR TITLE
Allow for a infinity of child menu's

### DIFF
--- a/Resources/views/layout/macros.html.twig
+++ b/Resources/views/layout/macros.html.twig
@@ -36,6 +36,8 @@
 {% endmacro %}
 
 {% macro menu_item(item) %}
+    {% import _self as macros %}
+    
     {% if item.route or item.hasChildren %}
         <li id="{{ item.identifier }}" class=" {{ item.isActive ? 'active' : '' }} {{ item.hasChildren? 'treeview' : '' }}">
             <a href="{{ item.hasChildren ? '#': '/' in item.route ? item.route : path(item.route, item.routeArgs) }}">
@@ -50,12 +52,7 @@
             {% if item.hasChildren %}
                 <ul class="treeview-menu">
                     {% for child in item.children %}
-                        <li class="{{ child.isActive ? 'active':'' }}" id="{{ child.identifier }}">
-                            <a href="{{ '/' in child.route ? child.route : path(child.route, child.routeArgs) }}">
-                                <i class="{{ child.icon|default('fa fa-circle-o') }}"></i>
-                                {{ child.label }}
-                            </a>
-                        </li>
+                        {{ macros.menu_item(child) }}
                     {% endfor %}
                 </ul>
             {% endif %}


### PR DESCRIPTION
This PR creates a support for a &infin; of submenu's or until the maximum function nesting level is reached for the sidebar.

There is a minor BC break here that will avoid adding the `fa fa-circle-o` by default for every child.
