### PR TITLE
Required field only if label is defined

### DIFF
--- a/Resources/views/layout/form-theme.html.twig
+++ b/Resources/views/layout/form-theme.html.twig
@@ -155,8 +155,8 @@
     {% endif %}
 
     {{ parent() }}
-    {% if required %}
-        <span class="required" title="Dies ist ein Pflichtfeld">*</span>
+    {% if required and label %}
+        <span class="required" title="{{ "This is a mandatory field"|trans({}, translation_domain) }}">*</span>
     {% endif %}
 
 {% endblock form_label %}


### PR DESCRIPTION
If label is set to "false" the required field is not shown. You can show it manually on placeholder or another. 
Added translation to title