### PR TITLE
Add link to breadcrumb component in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,6 @@ longer a strict requirement for bower and/or assetic. The assetic groups hovever
 * [Navbar Notifications](Resources/docs/navbar_notifications.md)
 * [Sidebar User](Resources/docs/sidebar_user.md)
 * [Sidebar Navigation](Resources/docs/sidebar_navigation.md)
-* 
+* [Breadcrumb Menu](Resources/docs/breadcrumbs.md)
 
  [1]: https://almsaeedstudio.com/themes/AdminLTE/documentation/index.html


### PR DESCRIPTION
After #95 was merged-in, the `Next steps` list at the bottom of the README was missing a link to the new breadcrumb component doc.
This merge request adds this link to the empty element at the end of the list.