### PR TITLE
Fix class for select field

### DIFF
--- a/Resources/views/layout/form-theme.html.twig
+++ b/Resources/views/layout/form-theme.html.twig
@@ -31,7 +31,13 @@
 {% endblock choice_widget_expanded %}
 
 {% block choice_widget_collapsed %}
-    {% set attr = attr|merge({'class' : 'form-control'}) %}
+
+    {% for att, val in attr %}
+        {% if att == 'class' %}
+            {% set att = val ~ ' form-control' %}
+        {% endif %}
+    {% endfor %}
+
     {{ parent() }}
 {% endblock %}
 


### PR DESCRIPTION
Prevent a double form-control class on select field and let add classes into form builder

`
  $builder->add('choice','choice', [
    'attr' => [
      'class' => 'select-class'
      ]
    ]);
`