### PR TITLE
Add blocks to differentiate page logo and title-page

### DIFF
--- a/Resources/docs/layout.md
+++ b/Resources/docs/layout.md
@@ -9,6 +9,10 @@ In order to use the layout, your views should extend from the provided base-layo
 <dl>
 <dt>title</dt>
 <dd>located in the title tag</dd>
+<dt>logo_mini (by default : value of title block)</dt>
+<dd>Define the logo for "sidebar-mini" mode</dd>
+<dt>logo_lg (by default : value of title block)</dt>
+<dd>Define the logo for desktop</dd>
 <dt>stylesheets</dt>
 <dd>located in the head. Please don't forget to use {{parent()}} when adding stylesheets in your view(s).</dd>
 <dt>javascripts_head</dt>
@@ -24,7 +28,6 @@ In order to use the layout, your views should extend from the provided base-layo
 <dt>javascripts_inline</dt>
 <dd>Instead of spreading inline scripts all over the page, you could use this block to group them.</dd>
 </dl>
-
 
 ### packaged assets
 the bundle comes with a set of pre packaged assets located under `Resources/public/static/[dev|prod]`. These are basically the assetic groups (see below) uglified and ready to use with the regular `{{ asset() }}` helper in combination with the application's environment.

--- a/Resources/views/layout/base-layout.html.twig
+++ b/Resources/views/layout/base-layout.html.twig
@@ -38,8 +38,10 @@
         <header class="main-header">
             {% block avanzu_logo %}
                 <a href="#" class="logo">
-                    <!-- Add the class icon to your logo image or logo icon to add the margining -->
-                    {{ block('title') }}
+	            <!-- Add the class icon to your logo image or logo icon to add the margining -->
+	            <span class="logo-mini">{% block logo_mini %}{{ block('title') }}{% endblock %}</span>
+	            <!-- logo for regular state and mobile devices -->
+	            <span class="logo-lg">{% block logo_lg %}{{ block('title') }}{% endblock %}</span>
                 </a>
             {% endblock %}
             <!-- Header Navbar: style can be found in header.less -->


### PR DESCRIPTION
English :
Currently, when we want to define the title of the page, We define the top-left logo at the same time, this prevents making style effects in the logo, or put an image.

So I created 2 new blocks: a block for the logo which will be visible in "mini-sidebar" and one for the logo visible when the menu is normal. For reasons of backward compatibility, the default setting is that of the title block
_____________________
French :
Actuellement, quand on définit le titre de la page, on définie en même temps le logo de la page, en haut a gauche. Cela empèche de faire des effets de style dans le logo, ou d'y mettre une image.

J'ai donc créer 2 nouveau blocks : un block pour le logo qui sera visible en mode "sidebar-mini" et un dernier pour le logo visible quand le menu est normal. Par soucis de rétrocompatibilité, la valeur par default est celle du block titre