### PR TITLE
Label of a checkbox or radio cannot be disabled

### DIFF
--- a/Resources/views/layout/form-theme.html.twig
+++ b/Resources/views/layout/form-theme.html.twig
@@ -50,7 +50,7 @@
             {% if required %}
                 {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' required')|trim}) %}
             {% endif %}
-            {% if label is empty %}
+            {% if label is not same as(false) and label is empty %}
                 {% set label = name|humanize %}
             {% endif %}
 
@@ -73,7 +73,7 @@
             {% if required %}
                 {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' required')|trim}) %}
             {% endif %}
-            {% if label is empty %}
+            {% if label is not same as(false) and label is empty %}
                 {% set label = name|humanize %}
             {% endif %}
             <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>


### PR DESCRIPTION
Setting a `'label' => false` will resolve at `{% if label is empty %}` to true, so a label cannot be disabled.