### PR TITLE
[Fix] Datepicker name

### DIFF
--- a/EventListener/SetupThemeListener.php
+++ b/EventListener/SetupThemeListener.php
@@ -43,7 +43,7 @@ class SetupThemeListener {
         $mng->registerStyle('ionicons', $css.'/ionicons.css');
         $mng->registerStyle('admin-lte', $css.'/AdminLTE.css', array('bootstrap-slider', 'fontawesome', 'ionicons','datatables'));
         $mng->registerStyle('bs-colorpicker', $css.'/colorpicker/bootstrap-colorpicker.css', array('admin-lte'));
-        $mng->registerStyle('daterangepicker', $css.'/daterangepicker/daterangepicker-bs3.css', array('admin-lte'));
+        $mng->registerStyle('daterangepicker', $css.'/daterangepicker/daterangepicker.css', array('admin-lte'));
         $mng->registerStyle('timepicker', $css.'/timepicker/bootstrap-timepicker.css', array('admin-lte'));
         $mng->registerStyle('wysiwyg', $css.'/bootstrap-wysihtml5/bootstrap3-wysihtml5.css', array('admin-lte'));
 

--- a/Resources/config/assets.php
+++ b/Resources/config/assets.php
@@ -73,7 +73,7 @@ return call_user_func(
             'admin_lte_forms_css'    => array(
                 'inputs' => array(
                     $lteCssBase.'plugins/colorpicker/bootstrap-colorpicker.css',
-                    $lteCssBase.'plugins/daterangepicker/daterangepicker-bs3.css',
+                    $lteCssBase.'plugins/daterangepicker/daterangepicker.css',
                     $lteCssBase.'plugins/timepicker/bootstrap-timepicker.css',
                     $lteCssBase.'plugins/iCheck/all.css',
                     $lteCssBase.'plugins/iCheck/square/_all.css',


### PR DESCRIPTION
Fix that solve unknown resource during assetic:dump 

The filename has been renamed from daterangepicker-bs3.css to daterangepicker.css
> The source file ".../web/bundles/avanzuadmintheme/vendor/adminlte/plugins/daterangepicker/daterangepicker-bs3.css" does not exist.
