### PR TITLE
changing jquery to lower case

### DIFF
--- a/Resources/views/Partials/_scripts.html.twig
+++ b/Resources/views/Partials/_scripts.html.twig
@@ -1,6 +1,6 @@
 
     <!-- jQuery 2.2.0 -->
-    <script src="{{ asset('theme/plugins/jQuery/jQuery-2.2.3.min.js') }}"></script>
+    <script src="{{ asset('theme/plugins/jQuery/jquery-2.2.3.min.js') }}"></script>
     <!-- Bootstrap 3.3.6 -->
     <script src="{{ asset('theme/bootstrap/js/bootstrap.min.js') }}"></script>
     <!-- AdminLTE App -->


### PR DESCRIPTION
lower-case on jquery - on my systems (osx, and linux) - the jquery is lowercase.
on OSX it isn't a problem because filesystem is insensitive - but on linux (production) it is an error.


i think it is better to lowercase it.
