### PR TITLE
Fixed Symfony doc link in layout.md

### DIFF
--- a/Resources/docs/layout.md
+++ b/Resources/docs/layout.md
@@ -95,4 +95,4 @@ The blocks defined in the layout in order of appearance. Some of them do contain
 <dd>Intended for inline scripts in order to keep those in one single document block.
 </dl>
 
-[1]: http://symfony.com/doc/current/book/templating.html#overriding-bundle-templates
+[1]: http://symfony.com/doc/current/templating/overriding.html


### PR DESCRIPTION
The "How to Override Templates from Third-Party Bundles" now has a separate page in the Symfony documentation. This pr links to the new page as the old paragraph doesn't exist any more.