### PR TITLE
Improved KnpMenu integration

### DIFF
--- a/Resources/docs/knp_menu.md
+++ b/Resources/docs/knp_menu.md
@@ -44,12 +44,42 @@ class SetupKnpMenuListener
     public function onSetupMenu(KnpMenuEvent $event)
     {
         $menu = $event->getMenu();
+        
+        // Adds a menu item which acts as a label
+        $menu->addChild('MainNavigationMenuItem', [
+       	    'label' => 'MAIN NAVIGATION',
+            'childOptions' => $event->getChildOptions()
+        ]
+        )->setAttribute('class', 'header');
+        
+        // A "regular" menu item with a link
         $menu->addChild('TestMenuItem', [
             'route' => 'homepage',
             'label' => 'Homepage',
             'childOptions' => $event->getChildOptions()
         ]
         )->setLabelAttribute('icon', 'fa fa-flag');
+        
+        // Adds a menu item which has children
+        $menu->addChild('DataMenuItem', [
+            'label' => 'Database mangement',
+            'childOptions' => $event->getChildOptions()
+        ]
+        )->setLabelAttribute('icon', 'fa fa-database');
+        // First child, a regular menu item
+        $menu->getChild('DataMenuItem')->addChild('DataUsersMenuItem', [
+            'route' => 'app.database.users',
+            'label' => 'Users table',
+            'childOptions' => $event->getChildOptions()
+        ]
+        )->setLabelAttribute('icon', 'fa fa-user');
+        // Second child, a regular menu item
+        $menu->getChild('DataMenuItem')->addChild('DataGroupsMenuItem', [
+            'route' => 'app.database.groups',
+            'label' => 'Groups table',
+            'childOptions' => $event->getChildOptions()
+        ]
+        )->setLabelAttribute('icon', 'fa fa-users');
     }
 }
 ```

--- a/Resources/views/Partials/_menu.html.twig
+++ b/Resources/views/Partials/_menu.html.twig
@@ -19,7 +19,8 @@
 
         {% if matcher.isAncestor(item) %}
             {%- set listAttributes = listAttributes|merge({class: (listAttributes.class|default('') ~ ' in')|trim}) -%}
-        {% else %}
+        {% endif %}
+        {% if not item.isRoot %}
             {%- set listAttributes = listAttributes|merge({class: (listAttributes.class|default('') ~ ' treeview-menu')|trim}) -%}
         {% endif %} 
         <ul{{ knp_menu.attributes(listAttributes) }}>

--- a/Resources/views/Partials/_menu.html.twig
+++ b/Resources/views/Partials/_menu.html.twig
@@ -19,7 +19,9 @@
 
         {% if matcher.isAncestor(item) %}
             {%- set listAttributes = listAttributes|merge({class: (listAttributes.class|default('') ~ ' in')|trim}) -%}
-        {% endif %}
+        {% else %}
+            {%- set listAttributes = listAttributes|merge({class: (listAttributes.class|default('') ~ ' treeview-menu')|trim}) -%}
+        {% endif %} 
         <ul{{ knp_menu.attributes(listAttributes) }}>
             {{ block('children') }}
         </ul>
@@ -35,11 +37,11 @@
 {% endmacro %}
 
 {% block spanElement %}
-    <a{{ _self.attributes(item.labelAttributes) }}>
+    {% if item.attribute('class') matches '/(^|\s+)header(\s+|$)/' %}
         {{ block('label') }}
-        {% if item.hasChildren %}
-            {#<b class="caret pull-right"></b>#}
-            {#<i class="fa fa-angle-double-right pull-right"></i>#}
-        {% endif %}
-    </a>
+    {% else %}
+        <a{{ _self.attributes(item.labelAttributes) }}>
+            {{ block('label') }}
+        </a>
+    {% endif %}
 {% endblock %}

--- a/Resources/views/Partials/_menu.html.twig
+++ b/Resources/views/Partials/_menu.html.twig
@@ -6,6 +6,11 @@
         <span>{% if options.allow_safe_labels and item.getExtra('safe_label', false) %}{{ item.label|trans|raw }}{% else %}{{ item.label|trans }}{% endif %}</span>
     {% endif %}
     {% if item.labelAttribute('data-image') %}<img src="{{ item.labelAttribute('data-image') }}" alt="{{ item.name }}" class="menu-thumbnail"/>{% endif %}
+    {% if item.hasChildren and options.depth is not same as(0) and item.displayChildren %}
+        <span class="pull-right-container">
+            <i class="fa fa-angle-left pull-right"></i>
+        </span>
+    {% endif %}
 {% endblock %}
 
 {% block list %}


### PR DESCRIPTION
- Added support for `.header` class used in AdminLTE
- Automatically add arrows to menu items with children, just like in AdminLTE preview
- Added show/hide functionality to menu items with children by adding `.treeview-menu` class to `<ul>` tag, just like in AdminLTE preview
- Updated documentation accordingly