### PR TITLE
fix name attribute in bower.json

### DIFF
--- a/Resources/bower/bower.json
+++ b/Resources/bower/bower.json
@@ -1,5 +1,5 @@
 {
-    "name"        : "AvanzuAdminTheme",
+    "name"        : "admin-theme-bundle",
     "version"     : "0.0.2",
     "authors"     : [
         "Marc Bach <mail@avanzu.de>"


### PR DESCRIPTION
With recent versions of `bower` and `npm`, a warning is displayed upon running the `avanzu:admin:fetch-vendor` command because the `name`attribute in `bower.json`contains uppercase letters.

```
[Executing] /usr/local/bin/bower install
[Error] bower                     invalid-meta The "name" is recommended to be lowercase, can contain digits, dots, dashes
```

As mentionned in the [bower.json spec](https://github.com/bower/spec/blob/master/json.md#name) : 

>The name of the package as stored in the registry.
> - Must be unique.
> - Should be slug style for simplicity, consistency and compatibility. Example: unicorn-cake
> - **Lowercase**, a-z, can contain digits, 0-9, can contain dash or dot but not start/end with them.
> - Consecutive dashes or dots not allowed.
> - 50 characters or less.
