### PR TITLE
Fix checkbox display

### DIFF
--- a/Resources/views/layout/form-theme.html.twig
+++ b/Resources/views/layout/form-theme.html.twig
@@ -17,7 +17,7 @@
     {% else %}
         {% set class = _class %}
     {% endif %}
-    {% if 'form-control' not in class  %}
+    {% if 'checkbox' not in types and 'form-control' not in class  %}
         {%  set class = class ~ ' form-control' %}
     {% endif %}
     {% set attr = attr|merge({'class' : class}) %}


### PR DESCRIPTION
Using form-control on "input type=checkbox" breaks normal rendering and behavior in Chrome (didn't test FF).
The class `form-control` applies the CSS rule `appearance:none` in this line:
https://github.com/almasaeed2010/AdminLTE/blob/master/dist/css/AdminLTE.css#L1272

If you check the sources at:
https://almsaeedstudio.com/themes/AdminLTE/pages/forms/general.html
you will see, that checkboxes are not meant to use the `form-control` class.