### PR TITLE
IS_AUTHENTICATED_REMEMBERED instead of _FULLY

### DIFF
--- a/Resources/views/layout/base-layout.html.twig
+++ b/Resources/views/layout/base-layout.html.twig
@@ -47,7 +47,7 @@
                 <a href="#" class="sidebar-toggle" data-toggle="offcanvas" role="button">
                     <span class="sr-only">Toggle navigation</span>
                 </a>
-                {% if app.user is not null and is_granted('IS_AUTHENTICATED_FULLY') %}
+                {% if app.user is not null and is_granted('IS_AUTHENTICATED_REMEMBERED') %}
                     <div class="navbar-custom-menu">
                         <ul class="nav navbar-nav">
                             {% block avanzu_navbar %}
@@ -68,7 +68,7 @@
             <!-- sidebar: style can be found in sidebar.less -->
             <section class="sidebar">
                 {% block avanzu_sidebar %}
-                    {% if app.user is not null and is_granted('IS_AUTHENTICATED_FULLY') %}
+                    {% if app.user is not null and is_granted('IS_AUTHENTICATED_REMEMBERED') %}
                         {{ render(controller('AvanzuAdminThemeBundle:Sidebar:userPanel')) }}
                         {{ render(controller('AvanzuAdminThemeBundle:Sidebar:searchForm')) }}
                     {% endif %}


### PR DESCRIPTION
When you use the "remember me" functionality of Symfony (and most likely the FOS User Bundle) you are getting a different role when coming back and authenticating through your cookie. Therefore I suggest to use IS_AUTHENTICATED_REMEMBERED role to also show user related content which is missing instead.