### PR TITLE
Fix errors with avanzu:admin:fetch-vendor and avanzu:admin:build-assets commands

### DIFF
--- a/EventListener/SetupThemeListener.php
+++ b/EventListener/SetupThemeListener.php
@@ -43,7 +43,7 @@ class SetupThemeListener {
         $mng->registerStyle('ionicons', $css.'/ionicons.css');
         $mng->registerStyle('admin-lte', $css.'/AdminLTE.css', array('bootstrap-slider', 'fontawesome', 'ionicons','datatables'));
         $mng->registerStyle('bs-colorpicker', $css.'/colorpicker/bootstrap-colorpicker.css', array('admin-lte'));
-        $mng->registerStyle('daterangepicker', $css.'/daterangepicker/daterangepicker-bs3.css', array('admin-lte'));
+        $mng->registerStyle('daterangepicker', $css.'/daterangepicker/daterangepicker.css', array('admin-lte'));
         $mng->registerStyle('timepicker', $css.'/timepicker/bootstrap-timepicker.css', array('admin-lte'));
         $mng->registerStyle('wysiwyg', $css.'/bootstrap-wysihtml5/bootstrap3-wysihtml5.css', array('admin-lte'));
 

--- a/Resources/bower/bower.json
+++ b/Resources/bower/bower.json
@@ -26,7 +26,7 @@
         "marionette"                : "*",
         "pickadate"                 : "*",
         "holderjs"                  : "*",
-        "bootflat"                  : "*",
+        "Bootflat"                  : "*",
         "bootbox"                   : "*",
         "fontawesome"               : "*",
         "ionicons"                  : "*",

--- a/Resources/config/assets.php
+++ b/Resources/config/assets.php
@@ -73,7 +73,7 @@ return call_user_func(
             'admin_lte_forms_css'    => array(
                 'inputs' => array(
                     $lteCssBase.'plugins/colorpicker/bootstrap-colorpicker.css',
-                    $lteCssBase.'plugins/daterangepicker/daterangepicker-bs3.css',
+                    $lteCssBase.'plugins/daterangepicker/daterangepicker.css',
                     $lteCssBase.'plugins/timepicker/bootstrap-timepicker.css',
                     $lteCssBase.'plugins/iCheck/all.css',
                     $lteCssBase.'plugins/iCheck/square/_all.css',


### PR DESCRIPTION
Fix theses errors :
[Error] bower bootflat#*          invalid-meta bootflat is missing "main" entry in bower.json
unable to process "/bundles/avanzuadmintheme/vendor/adminlte/plugins/daterangepicker/daterangepicker-bs3.css" with Error: ENOENT, no such file or directory '\bundles\avanzuadmintheme\vendor\adminlte\plugins\daterangepicker\daterangepicker-bs3.css'