### PR TITLE
fix Twig deprecation in menu.html.twig

### DIFF
--- a/Resources/views/Sidebar/menu.html.twig
+++ b/Resources/views/Sidebar/menu.html.twig
@@ -1,7 +1,7 @@
 <!-- sidebar menu: : style can be found in sidebar.less -->
-{% import "AvanzuAdminThemeBundle:layout:macros.html.twig" as macro %}
+{% from "AvanzuAdminThemeBundle:layout:macros.html.twig" import menu_item %}
 <ul class="sidebar-menu">
     {% for item in menu %}
-        {{ macro.menu_item(item) }}
+        {{ menu_item(item) }}
     {% endfor %}
 </ul>


### PR DESCRIPTION
Twig > 1.28 emits a deprecation warning in `Resources/views/Sidebar/menu.html.twig` because of the way the `menu_item` macro is imported.
`Calling "menu_item" on template "AvanzuAdminThemeBundle:Sidebar:menu.html.twig" from template "AvanzuAdminThemeBundle:Sidebar:menu.html.twig" is deprecated since version 1.28 and won't be supported anymore in 2.0.
`
Twig >= 2.0 doesn't support it.

See https://github.com/twigphp/Twig/issues/2267 for a more in depth explanation.