### PR TITLE
Fixed base layout errors by just removing non existing functions

### DIFF
--- a/Resources/views/layout/base-layout.html.twig
+++ b/Resources/views/layout/base-layout.html.twig
@@ -14,7 +14,6 @@
 
     {# -------------------------------------------------------------------------------------------------- STYLESHEETS #}
     {% block stylesheets %}
-        <link rel="stylesheet" href="{{ asset(admin_style_path()) }}" />
     {% endblock %}
 
 
@@ -22,12 +21,6 @@
 
     {# --------------------------------------------------------------------------------------------- JAVASCRIPTS_HEAD #}
     {%  block javascripts_head %}
-        <script type="text/javascript" src="{{ asset(admin_script_path('modernizr.js')) }}"></script>
-
-        <!--[if lt IE 9]>
-
-        <![endif]-->
-
     {% endblock %}
 
 </head>
@@ -123,7 +116,6 @@
 
 {# ------------------------------------------------------------------------------------------------------ JAVASCRIPTS #}
 {% block javascripts %}
-    <script src="{{ asset(admin_script_path()) }}"></script>
 {% endblock %}
 
 {# ----------------------------------------------------------------------------------------------- JAVASCRIPTS_INLINE #}


### PR DESCRIPTION
Not a proper fix as the base-layout.html.twig is still broken, but at least it won't causes application wide error.

Related #133 