### PR TITLE
Fixed macros.html.twig that does not show the exact value of submenu labels

### DIFF
--- a/Resources/views/layout/macros.html.twig
+++ b/Resources/views/layout/macros.html.twig
@@ -27,7 +27,7 @@
                         {% else %}
                             <li class="{{ child.isActive ? 'active':'' }}" id="{{ child.identifier }}">
                                 <a href="{{ '/' in child.route ? child.route : path(child.route, child.routeArgs) }}">
-                                    {{ menu.menu_item_content(item, '') }}
+                                    {{ menu.menu_item_content(child, '') }}
                                 </a>
                             </li>
                         {% endif %}


### PR DESCRIPTION
To correct the error that does not show the exact value of submenu labels in the sidebar menu. 

for example i tried ...
with an simple getMenu() in AdminThemeBundle/EventListener/SidebarSetupMenuDemoListener.php
![image](https://user-images.githubusercontent.com/32195068/31576476-e445b8a0-b0fb-11e7-95db-d3239de52e38.png)

We have ...
![image](https://user-images.githubusercontent.com/32195068/31576082-70ca76ba-b0f4-11e7-8512-aa59e96add6d.png)
with {{ menu.menu_item_content(item, '') }}
![image](https://user-images.githubusercontent.com/32195068/31576083-767d00a0-b0f4-11e7-860c-c8657e3292cb.png)
with {{ menu.menu_item_content(child, '') }}