### PR TITLE
Set null default value to max

### DIFF
--- a/Event/NotificationListEvent.php
+++ b/Event/NotificationListEvent.php
@@ -30,7 +30,7 @@ class NotificationListEvent extends ThemeEvent
      *
      * @param null $max
      */
-    public function __construct($max)
+    public function __construct($max = null)
     {
         $this->max = $max;
     }


### PR DESCRIPTION
This avoid this error:
Type error: Too few arguments to function Avanzu\AdminThemeBundle\Event\NotificationListEvent::__construct(), 0 passed in /var/www/html/cti/vendor/avanzu/admin-theme-bundle/Controller/NavbarController.php on line 39 and exactly 1 expected