### PR TITLE
<bugfix> Changed SpinJs version to 2.3.2

### DIFF
--- a/Resources/bower/bower.json
+++ b/Resources/bower/bower.json
@@ -22,7 +22,7 @@
         "backbone"                  : "*",
         "underscore"                : ">=1.0.0 <2.0",
         "modernizr"                 : ">=2.5.0 <3.0",
-        "spinjs"                    : "*",
+        "spinjs"                    : "2.3.2",
         "marionette"                : "*",
         "pickadate"                 : "*",
         "holderjs"                  : "*",


### PR DESCRIPTION
SpinJs was rewritten in TypeScript in Version 3.0 and 2.3.2 is the last version in written in JavaScript

➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖

⚠️⚠️⚠️  **THIS BUNDLE HAS ENTERED INTO ITS FEATURE FREEZE PERIOD**  ⚠️⚠️⚠️

  * Pull Requests with New Features will no longer be merged.
  * If you want to propose some new feature, please create an Issue.
  * Pull Requests that fix bugs are still accepted and greatly appreciated.

➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖➖

<!-- Note: all your contributions adhere implicitly to the MIT license -->
This time, it should work