### PR TITLE
Use AdminLTE 2.3.x (due to incompatibilities in 2.4)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "symfony/http-foundation" : ">=2.3",
         "symfony/http-kernel"  : ">=2.3",
         "symfony/event-dispatcher" : ">=2.3",
-        "almasaeed2010/adminlte": "^2.3"
+        "almasaeed2010/adminlte": "~2.3.0"
     },
     "require-dev": {
         "phpspec/prophecy": "^1.6"


### PR DESCRIPTION
The current composer setup would install https://github.com/almasaeed2010/AdminLTE/tree/v2.4.2/ which is incompatible due to its changed directory structure. 

For example:
- v2.3: https://github.com/almasaeed2010/AdminLTE/tree/v2.3.11/bootstrap/css
- v2.4: https://github.com/almasaeed2010/AdminLTE/tree/v2.4.2/bower_components/bootstrap/dist/css

This PR will pin the AdminLTE version to 2.3.x 
  
@shakaran Can you have a look, I assume that this fix is required for the 2.0 release.