### PR TITLE
Load commands explicit as auto-dicovery way deprecated in Symfony 3.4

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -39,5 +39,6 @@ services:
             - "%avanzu_admin_theme.options%"
             - "@avanzu_admin_theme.admin_router"
 
-
-
+    Avanzu\AdminThemeBundle\Command\:
+      resource: ../../Command
+      tags: [console.command]


### PR DESCRIPTION
Hi guys, 

with Symfony 3.4 auto-discovery for Commands was deprecated:
https://github.com/symfony/symfony/issues/23488
https://github.com/symfony/symfony/pull/23805

That means the AdminTheme Commands `avanzu:admin:*` are not available in case of deactivated auto-wiring. With Symfony 4 this is the default behaviour and the commands are never available.

While migrating a Project of mine to SF4, I couldn't properly initialize the theme as the commands wheren't available and I had to add the attached changes to services.yml to make them callable.

These 3 lines register the command directory for Service discovery and the commands will be available when executing bin/console.I tested it only with Symfony 4, but according to Symfony core devs it will at least work with 3.4 as well: https://github.com/symfony/symfony/issues/23488#issuecomment-315598669