### PR TITLE
Symfony 3.4 and 4 compatibility

### DIFF
--- a/Controller/BreadcrumbController.php
+++ b/Controller/BreadcrumbController.php
@@ -49,7 +49,7 @@ class BreadcrumbController extends Controller
             }
         }
 
-        return $this->render('AvanzuAdminThemeBundle:Breadcrumb:breadcrumb.html.twig', [
+        return $this->render('@AvanzuAdminTheme/Breadcrumb/breadcrumb.html.twig', [
                 'active' => $list,
                 'title' => $title,
             ]);

--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -18,36 +18,36 @@ class DefaultController extends Controller
      */
     public function indexAction()
     {
-        return $this->render('AvanzuAdminThemeBundle:Default:index.html.twig');
+        return $this->render('@AvanzuAdminTheme/Default/index.html.twig');
     }
 
     /**
      * @return \Symfony\Component\HttpFoundation\Response
      */
     public function dashboardAction() {
-        return $this->render('AvanzuAdminThemeBundle:Default:index.html.twig');
+        return $this->render('@AvanzuAdminTheme/Default/index.html.twig');
     }
 
     /**
      * @return \Symfony\Component\HttpFoundation\Response
      */
     public function uiGeneralAction() {
-        return $this->render('AvanzuAdminThemeBundle:Default:index.html.twig');
+        return $this->render('@AvanzuAdminTheme/Default/index.html.twig');
     }
 
     public function uiIconsAction() {
-        return $this->render('AvanzuAdminThemeBundle:Default:index.html.twig');
+        return $this->render('@AvanzuAdminTheme/Default/index.html.twig');
     }
 
     public function formAction() {
         $form = $this->createForm(FormDemoModelType::class);
 
-        return $this->render('AvanzuAdminThemeBundle:Default:form.html.twig', [
+        return $this->render('@AvanzuAdminTheme/Default/form.html.twig', [
                 'form' => $form->createView(),
             ]);
     }
 
     public function loginAction() {
-        return $this->render('AvanzuAdminThemeBundle:Default:login.html.twig');
+        return $this->render('@AvanzuAdminTheme/Default/login.html.twig');
     }
 }

--- a/Controller/NavbarController.php
+++ b/Controller/NavbarController.php
@@ -39,7 +39,7 @@ class NavbarController extends EmitterController
         $listEvent = $this->getDispatcher()->dispatch(ThemeEvents::THEME_NOTIFICATIONS, new NotificationListEvent());
 
         return $this->render(
-                    'AvanzuAdminThemeBundle:Navbar:notifications.html.twig',
+                    '@AvanzuAdminTheme/Navbar/notifications.html.twig',
                         [
                             'notifications' => $listEvent->getNotifications(),
                             'total' => $listEvent->getTotal(),
@@ -61,7 +61,7 @@ class NavbarController extends EmitterController
         $listEvent = $this->getDispatcher()->dispatch(ThemeEvents::THEME_MESSAGES, new MessageListEvent());
 
         return $this->render(
-                    'AvanzuAdminThemeBundle:Navbar:messages.html.twig',
+                    '@AvanzuAdminTheme/Navbar/messages.html.twig',
                         [
                             'messages' => $listEvent->getMessages(),
                             'total' => $listEvent->getTotal(),
@@ -83,7 +83,7 @@ class NavbarController extends EmitterController
         $listEvent = $this->triggerMethod(ThemeEvents::THEME_TASKS, new TaskListEvent($max));
 
         return $this->render(
-                    'AvanzuAdminThemeBundle:Navbar:tasks.html.twig',
+                    '@AvanzuAdminTheme/Navbar/tasks.html.twig',
                         [
                             'tasks' => $listEvent->getTasks(),
                             'total' => $listEvent->getTotal(),
@@ -105,7 +105,7 @@ class NavbarController extends EmitterController
 
         if ($userEvent instanceof ShowUserEvent) {
             return $this->render(
-                'AvanzuAdminThemeBundle:Navbar:user.html.twig',
+                '@AvanzuAdminTheme/Navbar/user.html.twig',
                 [
                     'user' => $userEvent->getUser(),
                     'links' => $userEvent->getLinks(),

--- a/Controller/SecurityController.php
+++ b/Controller/SecurityController.php
@@ -31,7 +31,7 @@ class SecurityController extends Controller
         }
 
         return $this->render(
-                    'AvanzuAdminThemeBundle:Security:login.html.twig',
+                    '@AvanzuAdminTheme/Security/login.html.twig',
                         [
                             'last_username' => $session->get(SecurityContext::LAST_USERNAME),
                             'error' => $error,

--- a/Controller/SidebarController.php
+++ b/Controller/SidebarController.php
@@ -29,7 +29,7 @@ class SidebarController extends Controller
         $userEvent = $this->getDispatcher()->dispatch(ThemeEvents::THEME_SIDEBAR_USER, new ShowUserEvent());
 
         return $this->render(
-                    'AvanzuAdminThemeBundle:Sidebar:user-panel.html.twig',
+                    '@AvanzuAdminTheme/Sidebar/user-panel.html.twig',
                         [
                             'user' => $userEvent->getUser(),
                         ]
@@ -51,7 +51,7 @@ class SidebarController extends Controller
      */
     public function searchFormAction()
     {
-        return $this->render('AvanzuAdminThemeBundle:Sidebar:search-form.html.twig', []);
+        return $this->render('@AvanzuAdminTheme/Sidebar/search-form.html.twig', []);
     }
 
     public function menuAction(Request $request)
@@ -63,7 +63,7 @@ class SidebarController extends Controller
         $event = $this->getDispatcher()->dispatch(ThemeEvents::THEME_SIDEBAR_SETUP_MENU, new SidebarMenuEvent($request));
 
         return $this->render(
-                    'AvanzuAdminThemeBundle:Sidebar:menu.html.twig',
+                    '@AvanzuAdminTheme/Sidebar/menu.html.twig',
                         [
                             'menu' => $event->getItems(),
                         ]

--- a/DependencyInjection/AvanzuAdminThemeExtension.php
+++ b/DependencyInjection/AvanzuAdminThemeExtension.php
@@ -117,7 +117,7 @@ class AvanzuAdminThemeExtension extends Extension implements PrependExtensionInt
                     'twig',
                     [
                         'form_theme' => [
-                            'AvanzuAdminThemeBundle:layout:form-theme.html.twig',
+                            '@AvanzuAdminTheme/layout/form-theme.html.twig',
                         ],
                         'globals' => [
                             'admin_theme' => '@avanzu_admin_theme.theme_manager',

--- a/DependencyInjection/Compiler/TwigPass.php
+++ b/DependencyInjection/Compiler/TwigPass.php
@@ -48,7 +48,7 @@ class TwigPass implements CompilerPassInterface
             $param = [];
         }
 
-        array_push($param, 'AvanzuAdminThemeBundle:layout:form-theme.html.twig');
+        array_push($param, '@AvanzuAdminTheme/layout/form-theme.html.twig');
 
         $container->setParameter('twig.form.resources', $param);
 

--- a/Event/ThemeEvents.php
+++ b/Event/ThemeEvents.php
@@ -35,7 +35,7 @@ class ThemeEvents
      * used to receive the current user for the sidebar
      * 
      * macro: avanzu_sidebar_user
-     * template: AvanzuAdminThemeBundle:Sidebar:user-panel.html.twig
+     * template: @AvanzuAdminTheme/Sidebar/user-panel.html.twig
      */
     const THEME_SIDEBAR_USER = 'theme.sidebar_user';
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -39,5 +39,6 @@ services:
             - "%avanzu_admin_theme.options%"
             - "@avanzu_admin_theme.admin_router"
 
-
-
+    Avanzu\AdminThemeBundle\Command\:
+      resource: ../../Command
+      tags: [console.command]

--- a/Resources/docs/form_theme.md
+++ b/Resources/docs/form_theme.md
@@ -6,7 +6,7 @@ allow customize the form elements in AdminTLE.
 This is used as:
 
 ```twig
-{% form_theme form 'AvanzuAdminThemeBundle:layout:form-theme.html.twig' %}
+{% form_theme form '@AvanzuAdminTheme/layout/form-theme.html.twig' %}
 ```
 
 For override the default theme in twig template you need put in the template which you want the new form theme
@@ -25,7 +25,7 @@ You also could apply this, only checking if a form is defined:
 
 ```twig
 {% if form is defined %}
-    {% form_theme form 'AvanzuAdminThemeBundle:layout:form-theme.html.twig' %}
+    {% form_theme form '@AvanzuAdminTheme/layout/form-theme.html.twig' %}
 {% endif %}
 ```
 
@@ -34,5 +34,5 @@ Also is possible override the form theme by referencing
 only customize/override some childs elements in the form like:
 
 ```twig
-{% form_theme form.submit 'AvanzuAdminThemeBundle:layout:form-theme.html.twig' %}
+{% form_theme form.submit '@AvanzuAdminTheme/layout/form-theme.html.twig' %}
 ```

--- a/Resources/docs/layout.md
+++ b/Resources/docs/layout.md
@@ -4,7 +4,7 @@ Note: this instrucions are for [dev-master branch][4], if you are using stable v
 
 In order to use the layout, your views should extend from the provided `default-layout`
 ```twig
-{% extends 'AvanzuAdminThemeBundle:layout:default-layout.html.twig' %}
+{% extends '@AvanzuAdminTheme/layout/default-layout.html.twig' %}
 ```
 ### twig global 
 Instead of fully relying on blocks and includes, you are provided with a twig global named `avanzu_admin_context` to store and retrieve particular values throughout the page rendering. 
@@ -16,19 +16,19 @@ In order to make overriding some of the template regions easier, there are sever
 Listed in the order of appearance, these are:
 
 <dl>
-<dt>AvanzuAdminThemeBundle:Partials:_head.html.twig
+<dt>@AvanzuAdminTheme/Partials/_head.html.twig
 <dd>Defines the `head` tag contents.
-<dt>AvanzuAdminThemeBundle:Sidebar:knp-menu.html.twig
+<dt>@AvanzuAdminTheme/Sidebar/knp-menu.html.twig
 <dd>Renders the knp menu using the builder defined as `main_menu`. 
 <br/>___Notice___ *this partial will only be included when the knp_menu is enabled.*
-<dt>AvanzuAdminThemeBundle:Breadcrumb:knp-breadcrumb.html.twig
+<dt>@AvanzuAdminTheme/Breadcrumb/knp-breadcrumb.html.twig
 <dd>Rendes the knp menu using the builder defined as `breadcrumb_menu` 
 <br/>___Notice___ *this partial will only be included when the knp_menu is enabled.*
-<dt>AvanzuAdminThemeBundle:Partials:_footer.html.twig
+<dt>@AvanzuAdminTheme/Partials/_footer.html.twig
 <dd>Renders the main footer
-<dt>AvanzuAdminThemeBundle:Partials:_control-sidebar.html.twig
+<dt>@AvanzuAdminTheme/Partials/_control-sidebar.html.twig
 <dd>Renders the control sidebar (righthand panel) unless it is disabled in the config (default)
-<dt>AvanzuAdminThemeBundle:Partials:_scripts.html.twig
+<dt>@AvanzuAdminTheme/Partials/_scripts.html.twig
 <dd>Renders script tags. Located right before the closing `body`. 
 </dl>
 
@@ -85,7 +85,7 @@ The blocks defined in the layout in order of appearance. Some of them do contain
 <dd>Renders the `searchPanel` component
 
 <dt>avanzu_sidebar_nav
-<dd>Renders the `menu` component _or_ includes `AvanzuAdminThemeBundle:Sidebar:knp-menu.html.twig` depending on wether the `knp_menu` is enabled or not. 
+<dd>Renders the `menu` component _or_ includes `@AvanzuAdminTheme/Sidebar/knp-menu.html.twig` depending on wether the `knp_menu` is enabled or not. 
 
 <dt>avanzu_page_title
 <dd>Defines the page header inside `.content-header` *(and implicitly the `title` if you haven't changed the content of `avanzu_document_title`)*
@@ -94,16 +94,16 @@ The blocks defined in the layout in order of appearance. Some of them do contain
 <dd>Defines the `small` portion of `.content-header`
 
 <dt>avanzu_breadcrumb
-<dd>Renders either the `breadcrumb` component or includes `AvanzuAdminThemeBundle:Breadcrumb:knp-breadcrumb.html.twig` based on your configuration.
+<dd>Renders either the `breadcrumb` component or includes `@AvanzuAdminTheme/Breadcrumb/knp-breadcrumb.html.twig` based on your configuration.
 
 <dt>avanzu_page_content
 <dd>The main content area. 
 
 <dt>avanzu_footer
-<dd>The main footer. Includes `AvanzuAdminThemeBundle:Partials:_footer.html.twig` by default.
+<dd>The main footer. Includes `@AvanzuAdminTheme/Partials/_footer.html.twig` by default.
 
 <dt>avanzu_control_sidebar
-<dd>Includes `AvanzuAdminThemeBundle:Partials:_control-sidebar.html.twig` if it is enabled.
+<dd>Includes `@AvanzuAdminTheme/Partials/_control-sidebar.html.twig` if it is enabled.
 
 <dt>avanzu_javascripts
 <dd>comes right after the `_scripts.html.twig` partial.

--- a/Resources/docs/twig_widgets.md
+++ b/Resources/docs/twig_widgets.md
@@ -35,7 +35,7 @@ avanzu_admin_theme:
 ## box-widget.html.twig
 
 ```twig
-{% embed 'AvanzuAdminThemeBundle:Widgets:box-widget.html.twig' %}
+{% embed '@AvanzuAdminTheme/Widgets/box-widget.html.twig' %}
     {% block box_title %}
     	{# Title goes here #}
     {% endblock %}
@@ -99,7 +99,7 @@ _**Notice:** since FALSE will not be considered a value by twig and therefor act
 ## infobox-widget
 The infobox widget has no default configuration. The very nature of this widget type is to be distinguishable from each other hence, the configuration would be overridden anyways.
 ```twig
-{% embed 'AvanzuAdminThemeBundle:Widgets:infobox-widget.html.twig'  with {
+{% embed '@AvanzuAdminTheme/Widgets/infobox-widget.html.twig'  with {
     'color' : 'aqua',
     'icon'  : 'comments-o',
     }%}

--- a/Resources/views/Default/form.html.twig
+++ b/Resources/views/Default/form.html.twig
@@ -1,5 +1,5 @@
-{% extends 'AvanzuAdminThemeBundle:layout:default-layout.html.twig' %}
-{% block avanzu_head %} {% include 'AvanzuAdminThemeBundle:Partials:_header-form-extra.html.twig' %}{% endblock %}
+{% extends '@AvanzuAdminTheme/layout/default-layout.html.twig' %}
+{% block avanzu_head %} {% include '@AvanzuAdminTheme/Partials/_header-form-extra.html.twig' %}{% endblock %}
 
 {% block avanzu_page_title %} {{ 'avanzu_admin_theme.default.form.forms'|trans({}, 'AvanzuAdminTheme') }} {% endblock %}
 {% block avanzu_page_subtitle %} {{ 'avanzu_admin_theme.default.form.demonstration'|trans({}, 'AvanzuAdminTheme') }} {% endblock %}
@@ -23,7 +23,7 @@
         <div class="col-md-6">
 
 
-            {% embed 'AvanzuAdminThemeBundle:Widgets:box-widget.html.twig' %}
+            {% embed '@AvanzuAdminTheme/Widgets/box-widget.html.twig' %}
                 {% block box_before %}{{ form_start(form) }}{% endblock %}
                 {% block box_title %}{{ 'Form theme'|trans({}, 'AvanzuAdminTheme') }}{% endblock %}
                 {% block box_body %}{{ form_widget(form) }}{% endblock %}
@@ -48,7 +48,7 @@
 
 {% endblock %}
 
-{% block avanzu_javascripts %}{% include 'AvanzuAdminThemeBundle:Partials:_scripts-form-extra.html.twig' %}{% endblock %}
+{% block avanzu_javascripts %}{% include '@AvanzuAdminTheme/Partials/_scripts-form-extra.html.twig' %}{% endblock %}
 {% block avanzu_javascripts_inline %}
     <script>
         $(function () {

--- a/Resources/views/Default/index.html.twig
+++ b/Resources/views/Default/index.html.twig
@@ -1,10 +1,10 @@
-{% extends 'AvanzuAdminThemeBundle:layout:default-layout.html.twig' %}
+{% extends '@AvanzuAdminTheme/layout/default-layout.html.twig' %}
 
 {% block avanzu_page_content %}
     <div class="row">
         <div class="col-md-6">
             {# ... infobox widget, solid background ... #}
-            {% embed 'AvanzuAdminThemeBundle:Widgets:infobox-widget.html.twig'  with {
+            {% embed '@AvanzuAdminTheme/Widgets/infobox-widget.html.twig'  with {
             'solid' : 'red',
             'icon'  : 'star-o',
             'progress' : 40
@@ -18,7 +18,7 @@
         <div class="col-md-6">
 
             {# ... infobox widget, colored icon ... #}
-            {% embed 'AvanzuAdminThemeBundle:Widgets:infobox-widget.html.twig'  with {
+            {% embed '@AvanzuAdminTheme/Widgets/infobox-widget.html.twig'  with {
             'color' : 'aqua',
             'icon'  : 'comments-o',
             } %}
@@ -32,9 +32,9 @@
     <div class="row">
         <div class="col-md-6">
             {# ... box widget with defaults ... #}
-            {% embed 'AvanzuAdminThemeBundle:Widgets:box-widget.html.twig' %}
+            {% embed '@AvanzuAdminTheme/Widgets/box-widget.html.twig' %}
 
-                {% import 'AvanzuAdminThemeBundle:Macros:buttons.html.twig'  as btn %}
+                {% import '@AvanzuAdminTheme/Macros/buttons.html.twig'  as btn %}
                 {% block box_title %}{{ 'Widget box title'|trans({}, 'AvanzuAdminTheme') }}{% endblock %}
                 {% block box_body %}
                     <div class="callout callout-info">
@@ -54,14 +54,14 @@
         </div>
         <div class="col-md-6">
             {# ... box widget with some options ... #}
-            {% embed 'AvanzuAdminThemeBundle:Widgets:box-widget.html.twig' with {
+            {% embed '@AvanzuAdminTheme/Widgets/box-widget.html.twig' with {
             'boxtype' : 'success',
             'solid' : 0,
             'collapsible' : 'Collapse this'|trans({}, 'AvanzuAdminTheme') ~ '... ',
             'removable' : 'Remove this'|trans({}, 'AvanzuAdminTheme') ~ '...',
             } %}
 
-                {% import 'AvanzuAdminThemeBundle:Macros:buttons.html.twig'  as btn %}
+                {% import '@AvanzuAdminTheme/Macros/buttons.html.twig'  as btn %}
                 {% block box_title %}{{ 'Widget box title' }}{% endblock %}
                 {% block box_body %}
                     <div class="callout callout-info">

--- a/Resources/views/Default/login.html.twig
+++ b/Resources/views/Default/login.html.twig
@@ -1,4 +1,4 @@
-{% extends 'AvanzuAdminThemeBundle:layout:login-layout.html.twig' %}
+{% extends '@AvanzuAdminTheme/layout/login-layout.html.twig' %}
 
 {% block page_content %}
     <div class="login-box">
@@ -20,7 +20,7 @@
                     <div class="col-xs-8">
                         <div class="checkbox">
                             <label>
-                                <input type="checkbox"> {{ 'Remember Me'|trans({}, 'AvanzuAdminTheme') }} 
+                                <input type="checkbox"> {{ 'Remember Me'|trans({}, 'AvanzuAdminTheme') }}
                             </label>
                         </div>
                     </div><!-- /.col -->

--- a/Resources/views/Exception/exception_full.html.twig
+++ b/Resources/views/Exception/exception_full.html.twig
@@ -1,4 +1,4 @@
-{% extends 'AvanzuAdminThemeBundle:layout:base-layout.html.twig' %}
+{% extends '@AvanzuAdminTheme/layout/base-layout.html.twig' %}
 {% block page_title %} Error {% endblock %}
 {% block page_subtitle %} {{ status_code }} {% endblock %}
 

--- a/Resources/views/Navbar/messages.html.twig
+++ b/Resources/views/Navbar/messages.html.twig
@@ -1,5 +1,5 @@
 <!-- Messages: style can be found in dropdown.less-->
-{% import "AvanzuAdminThemeBundle:layout:macros.html.twig" as macro %}
+{% import "@AvanzuAdminTheme/layout/macros.html.twig" as macro %}
 <li class="dropdown messages-menu">
     <a href="#" class="dropdown-toggle" data-toggle="dropdown">
         <i class="fa fa-envelope-o"></i>

--- a/Resources/views/Navbar/user.html.twig
+++ b/Resources/views/Navbar/user.html.twig
@@ -2,7 +2,7 @@
 {# @var links \Avanzu\AdminThemeBundle\Model\NavBarUserLink[] #}
 {# @var showProfileLink bool #}
 {# @var showLogoutLink bool #}
-{% import "AvanzuAdminThemeBundle:layout:macros.html.twig" as macro %}
+{% import "@AvanzuAdminTheme/layout/macros.html.twig" as macro %}
 <li class="dropdown user user-menu">
     <a href="#" class="dropdown-toggle" data-toggle="dropdown">
         {{ macro.avatar(user.avatar, user.username, 'user-image') }}

--- a/Resources/views/Security/login.html.twig
+++ b/Resources/views/Security/login.html.twig
@@ -1,1 +1,1 @@
-{% extends 'AvanzuAdminThemeBundle:layout:login-layout.html.twig' %}
+{% extends '@AvanzuAdminTheme/layout/login-layout.html.twig' %}

--- a/Resources/views/Sidebar/knp-menu.html.twig
+++ b/Resources/views/Sidebar/knp-menu.html.twig
@@ -1,6 +1,6 @@
 {{
     knp_menu_render(avanzu_admin_context.knp_menu.main_menu, {
-        "template"      : "AvanzuAdminThemeBundle:Partials:_menu.html.twig",
+        "template"      : "@AvanzuAdminTheme/Partials/_menu.html.twig",
         "currentClass"  : "active",
         "ancestorClass" : "active"
     })

--- a/Resources/views/Sidebar/menu.html.twig
+++ b/Resources/views/Sidebar/menu.html.twig
@@ -1,5 +1,5 @@
 <!-- sidebar menu: : style can be found in sidebar.less -->
-{% from "AvanzuAdminThemeBundle:layout:macros.html.twig" import menu_item %}
+{% from "@AvanzuAdminTheme/layout/macros.html.twig" import menu_item %}
 <ul class="sidebar-menu">
     {% for item in menu %}
         {{ menu_item(item) }}

--- a/Resources/views/Sidebar/user-panel.html.twig
+++ b/Resources/views/Sidebar/user-panel.html.twig
@@ -1,4 +1,4 @@
-{% import "AvanzuAdminThemeBundle:layout:macros.html.twig" as macro %}
+{% import "@AvanzuAdminTheme/layout/macros.html.twig" as macro %}
 <!-- Sidebar user panel -->
 <div class="user-panel">
     <div class="pull-left image">

--- a/Resources/views/Widgets/box-widget.html.twig
+++ b/Resources/views/Widgets/box-widget.html.twig
@@ -1,4 +1,4 @@
-{% import 'AvanzuAdminThemeBundle:Macros:buttons.html.twig' as button %}
+{% import '@AvanzuAdminTheme/Macros/buttons.html.twig' as button %}
 {% if block('box_before') is defined %}{{ block('box_before') }}{% endif %}
 
 {% set _collapsed = collapsed|default(false) %}

--- a/Resources/views/layout/base-layout.html.twig
+++ b/Resources/views/layout/base-layout.html.twig
@@ -1,4 +1,4 @@
-{% import "AvanzuAdminThemeBundle:layout:macros.html.twig" as macro %}
+{% import "@AvanzuAdminTheme/layout/macros.html.twig" as macro %}
 <!doctype html{% block avanzu_html_start %}{% endblock %}>
 <!--[if lt IE 7 ]><html lang="en" class="no-js ie6"> <![endif]-->
 <!--[if IE 7 ]><html lang="en" class="no-js ie7"> <![endif]-->

--- a/Resources/views/layout/default-layout.html.twig
+++ b/Resources/views/layout/default-layout.html.twig
@@ -8,7 +8,7 @@ scratch. This page gets rid of all links and provides the needed markup only.
     <title>
         {% block avanzu_document_title %}{{ block('avanzu_page_title') }}{% endblock %}
     </title>
-    {% include('AvanzuAdminThemeBundle:Partials:_head.html.twig') %}
+    {% include('@AvanzuAdminTheme/Partials/_head.html.twig') %}
     {% block avanzu_head %}{% endblock %}
 </head>
 {#
@@ -251,7 +251,7 @@ desired effect
 
             {% block avanzu_sidebar_nav %}
                 {% if avanzu_admin_context.knp_menu.enable %}
-                    {% include 'AvanzuAdminThemeBundle:Sidebar:knp-menu.html.twig' %}
+                    {% include '@AvanzuAdminTheme/Sidebar/knp-menu.html.twig' %}
                 {% else %}
                     {{ render(controller('AvanzuAdminThemeBundle:Sidebar:menu', {'request':app.request})) }}
                 {% endif %}
@@ -312,7 +312,7 @@ desired effect
 
             {% block avanzu_breadcrumb %}
                 {% if avanzu_admin_context.knp_menu.enable %}
-                    {% include 'AvanzuAdminThemeBundle:Breadcrumb:knp-breadcrumb.html.twig' %}
+                    {% include '@AvanzuAdminTheme/Breadcrumb/knp-breadcrumb.html.twig' %}
                 {% else %}
                     {{ render(controller('AvanzuAdminThemeBundle:Breadcrumb:breadcrumb', {'request':app.request, 'title' : block('avanzu_page_title')})) }}
                 {% endif %}
@@ -336,18 +336,18 @@ desired effect
     <!-- Main Footer -->
 
     {% block avanzu_footer %}
-        {% include 'AvanzuAdminThemeBundle:Partials:_footer.html.twig' %}
+        {% include '@AvanzuAdminTheme/Partials/_footer.html.twig' %}
     {% endblock %}
     {% block avanzu_control_sidebar %}
         {% if avanzu_admin_context.control_sidebar %}
-            {% include 'AvanzuAdminThemeBundle:Partials:_control-sidebar.html.twig' %}
+            {% include '@AvanzuAdminTheme/Partials/_control-sidebar.html.twig' %}
         {% endif %}
     {% endblock %}
 </div>
 <!-- ./wrapper -->
 <!-- REQUIRED JS SCRIPTS -->
 
-{% include 'AvanzuAdminThemeBundle:Partials:_scripts.html.twig' %}
+{% include '@AvanzuAdminTheme/Partials/_scripts.html.twig' %}
 {% block avanzu_javascripts %}{% endblock %}
 {% block avanzu_javascripts_inline %}{% endblock %}
 

--- a/Resources/views/layout/form-theme.html.twig
+++ b/Resources/views/layout/form-theme.html.twig
@@ -153,16 +153,13 @@
         <div class="form-group {{ errors|length > 0 ? 'has-error has-feedback'  : '' }}">
             {{ form_label(form) }}
             {{ form_widget(form) }}
+            {{ form_help(form) }}
             {{ form_errors(form) }}
         </div>
     {% endif %}
 {% endblock %}
 
 {% block form_label %}
-
-    {% if help is defined and help is not empty %}
-        &nbsp; <a href="#" data-toggle="tooltip" data-original-title="{{ help }}"><i class="fa fa-question-circle"></i></a>
-    {% endif %}
 
     {{ parent() }}
     {% if required and label is not same as (false) %}

--- a/Resources/views/layout/login-fosuserbundle.html.twig
+++ b/Resources/views/layout/login-fosuserbundle.html.twig
@@ -1,4 +1,4 @@
-{% extends 'AvanzuAdminThemeBundle:layout:login-layout.html.twig' %}
+{% extends '@AvanzuAdminTheme/layout/login-layout.html.twig' %}
 
 {# 
 This is a base template for login page which integrates 


### PR DESCRIPTION
After upgrading to Symfony 4 the AdminThemeBundle stopped working (see #215 as well).
All twig files could not be loaded with the current reference style, it always ended up with an  exception like "The file AvanzuAdminThemeBundle:Default:index.html.twig could not be found".

I did a quick research but couldn't find out why the template loader stopped working with the current syntax in master. It worked for me in 3.3, but stopped after the migration to SF4.

If I read the  docs for the latest versions:
- https://symfony.com/doc/current/templating.html#referencing-templates-in-a-bundle
- https://symfony.com/doc/3.4/templating.html#referencing-templates-in-a-bundle

both versions say 
> If you need to refer to a template that lives in a bundle, Symfony uses the Twig namespaced syntax (@ BundleName/directory/filename.html.twig). 

I clearly understand if you @shakaran don't want to risk BC breaks and reject the merge (for now), but I though I leave that PR for others users who want to upgrade to Symfony 4 and have troubles getting their site up again.