### PR TITLE
Allow dynamic option change during runtime

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -31,7 +31,7 @@ services:
         class: "%avanzu_admin_theme.extension.class%"
         tags:
             - { name: twig.extension }
-        arguments: ['%avanzu_admin_theme.options%', '%kernel.environment%', "@avanzu_admin_theme.admin_router"]
+        arguments: ['@avanzu_admin_theme.context_helper', '%kernel.environment%', "@avanzu_admin_theme.admin_router"]
 
     avanzu_admin_theme.context_helper:
         class: "%avanzu_admin_theme.context_helper.class%"
@@ -39,5 +39,7 @@ services:
             - "%avanzu_admin_theme.options%"
             - "@avanzu_admin_theme.admin_router"
 
+    Avanzu\AdminThemeBundle\Helper\ContextHelper:
+        alias: avanzu_admin_theme.context_helper
 
 

--- a/Twig/AvanzuAdminExtension.php
+++ b/Twig/AvanzuAdminExtension.php
@@ -7,11 +7,18 @@
 
 namespace Avanzu\AdminThemeBundle\Twig;
 
+use Avanzu\AdminThemeBundle\Helper\ContextHelper;
 use Avanzu\AdminThemeBundle\Routing\RouteAliasCollection;
 
 class AvanzuAdminExtension extends \Twig_Extension
 {
-    protected $options;
+    /**
+     * @var ContextHelper
+     */
+    protected $context;
+    /**
+     * @var string
+     */
     protected $env;
     /**
      * @var RouteAliasCollection
@@ -20,14 +27,13 @@ class AvanzuAdminExtension extends \Twig_Extension
 
     /**
      * AvanzuAdminExtension constructor.
-     *
-     * @param                      $options
-     * @param                      $env
+     * @param ContextHelper $contextHelper
+     * @param $env
      * @param RouteAliasCollection $aliasRouter
      */
-    public function __construct($options, $env, RouteAliasCollection $aliasRouter)
+    public function __construct(ContextHelper $contextHelper, $env, RouteAliasCollection $aliasRouter)
     {
-        $this->options = $options;
+        $this->context = $contextHelper;
         $this->env = $env;
         $this->aliasRouter = $aliasRouter;
     }
@@ -43,7 +49,7 @@ class AvanzuAdminExtension extends \Twig_Extension
     public function bodyClass($classes = '')
     {
         $classList = [$classes];
-        $options = $this->options;
+        $options = $this->context->getOptions();
 
         if(isset($options['skin'])) $classList[] = $options['skin'];
         if(isset($options['fixed_layout']) && true == $options['fixed_layout']) $classList[] = 'fixed';


### PR DESCRIPTION
Hi @shakaran ,

another PR with two non BC break changes:
- using context helper to load body_class options
- added service alias for auto-wiring

The Service alias is required for auto-wiring via constructor annotation.
Using the context helper allows us to change the body class options during runtime. 

Use-Case: I added a EventSubscriber that listen on the `kernel.controller` event and which then dynamically loads the `skin`option from a user preference from the database. I used `ContextHelper->setOption()` to set the skin but it did not change in the frontend.

Why? Currently in master the Twig helper gets a static copy of the options array, where another copy is injected into the ContextHelper. This builds the internal options from that copy & the user config but doesn't use it (at least not in the TwigExtensions helper).

I believe this is a programmatically bug or I completely misunderstood the ContextHelper?!?