### PR TITLE
Support additional blocks in login layout

### DIFF
--- a/Resources/views/layout/login-layout.html.twig
+++ b/Resources/views/layout/login-layout.html.twig
@@ -27,7 +27,6 @@
     <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
     {% block avanzu_head %}{% endblock %}
-    {%  block javascripts_head %}{% endblock %}
 </head>
 <body{% block avanzu_body_start %}{% endblock %} class="hold-transition login-page">
 {% block avanzu_after_body_start %}{% endblock %}
@@ -117,12 +116,8 @@
         });
     });
 </script>
-{# ------------------------------------------------------------------------------------------------------ JAVASCRIPTS #}
-{% block javascripts %}
-{% endblock %}
 
-{# ----------------------------------------------------------------------------------------------- JAVASCRIPTS_INLINE #}
-{% block javascripts_inline %}
-{% endblock %}
+{% block javascripts %}{% endblock %}
+{% block javascripts_inline %}{% endblock %}
 </body>
 </html>

--- a/Resources/views/layout/login-layout.html.twig
+++ b/Resources/views/layout/login-layout.html.twig
@@ -26,6 +26,8 @@
     <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
     <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+    {% block avanzu_head %}{% endblock %}
+    {%  block javascripts_head %}{% endblock %}
 </head>
 <body{% block avanzu_body_start %}{% endblock %} class="hold-transition login-page">
 {% block avanzu_after_body_start %}{% endblock %}
@@ -115,5 +117,12 @@
         });
     });
 </script>
+{# ------------------------------------------------------------------------------------------------------ JAVASCRIPTS #}
+{% block javascripts %}
+{% endblock %}
+
+{# ----------------------------------------------------------------------------------------------- JAVASCRIPTS_INLINE #}
+{% block javascripts_inline %}
+{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
Added some twig blocks, which are available in already existing in the default-layout.html.twig
- https://github.com/avanzu/AdminThemeBundle/blob/master/Resources/views/layout/default-layout.html.twig#L12
- https://github.com/avanzu/AdminThemeBundle/blob/master/Resources/views/layout/default-layout.html.twig#L351

Without these blocks we cannot easily extend the login layout.

