### PR TITLE
Added blocks for managing the pages main content

### DIFF
--- a/Resources/views/layout/default-layout.html.twig
+++ b/Resources/views/layout/default-layout.html.twig
@@ -325,11 +325,15 @@ desired effect
             #}
         </section>
 
+        {% block avanzu_page_content_before %}{% endblock %}
+
         <!-- Main content -->
-        <section class="content">
+        <section class="{% block avanzu_page_content_class %}content{% endblock %}">
             {% block avanzu_page_content %}{% endblock %}
         </section>
         <!-- /.content -->
+
+        {% block avanzu_page_content_after %}{% endblock %}
     </div>
     <!-- /.content-wrapper -->
 


### PR DESCRIPTION
Hi @shakaran,

I wanted to integrate the Invoice template from the official demos: 
https://adminlte.io/themes/AdminLTE/pages/examples/invoice.html

But I failed with the `default-layout.html.twig` as I could neither change the `<section>` class name (it needs to be `invoice` instead of `content`) nor could I add the required `<div clearfix>` after the content. 
I don't need the `callout` widget on top, but thought that I add the `avanzu_page_content_before` block there as well, for the ones who want to inject some widgets before the pages main content.

I know currently its feature freeze, but it does not introduce any BC break.
I can add documentation, but wanted to ask first what you think about the proposed changes.