### PR TITLE
Hotfix 1.3.5

### DIFF
--- a/Resources/bower/bower.json
+++ b/Resources/bower/bower.json
@@ -22,7 +22,7 @@
         "backbone"                  : "*",
         "underscore"                : ">=1.0.0 <2.0",
         "modernizr"                 : ">=2.5.0 <3.0",
-        "spinjs"                    : "*",
+        "spinjs"                    : "2.3.2",
         "marionette"                : "*",
         "pickadate"                 : "*",
         "holderjs"                  : "*",


### PR DESCRIPTION
When tagging 1.3.9, the change that was introduced and tagged in 1.3.8 (SpinJs version lock) was lost.

This is because the FontAwesome problem was solved patching 1.3.7 instead of 1.3.8.

This pull request is trying to carry-on the simple change introduced in 1.3.8.

This would solve Issue #226 

Please, accept the request and tag as 1.3.10