### PR TITLE
Fixes issue #240 - Locks down bower ionicons to stable 2.0.1

### DIFF
--- a/Resources/bower/bower.json
+++ b/Resources/bower/bower.json
@@ -29,7 +29,7 @@
         "bootflat"                  : "*",
         "bootbox"                   : "*",
         "fontawesome"               : "4.*",
-        "ionicons"                  : "*",
+        "ionicons"                  : "2.0.1",
         "fullcalendar"              : "*",
         "adminlte"                  : "~2.3.0"
     }


### PR DESCRIPTION
Locks down ionicons to stable 2.0.1 as per issue #240 comments.

See this:
https://github.com/avanzu/AdminThemeBundle/issues/240
https://github.com/ionic-team/ionicons/releases?after=v4.0.0-10
