### PR TITLE
fix bootbox version

### DIFF
--- a/Resources/bower/bower.json
+++ b/Resources/bower/bower.json
@@ -27,7 +27,7 @@
         "pickadate"                 : "*",
         "holderjs"                  : "*",
         "bootflat"                  : "*",
-        "bootbox"                   : "*",
+        "bootbox"                   : "4.4.0",
         "fontawesome"               : "4.*",
         "ionicons"                  : "2.0.1",
         "fullcalendar"              : "*",


### PR DESCRIPTION
Fix bootbox version.

Bootbox was created new version [5.0.0](https://github.com/makeusabrew/bootbox/tree/v5.x) and now appear error Unable to find file "@AvanzuAdminThemeBundle/Resources/public/vendor/bootbox/bootbox.js"
when execute assetic:dump command. Bootbox 5.0.0 have a different structure, and not compatible with 4.x

<!-- Note: all your contributions adhere implicitly to the MIT license -->
